### PR TITLE
Update SessionData to v2025.1.2 and add HackMD integration

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7000bfdd142c92db698957e84c2e17c94432db50e44fa5ae8dc84b1bc81f5f6b",
+  "originHash" : "0caf1cf78a0a2c9a5351dec94950bb99eec9c60d306c53bee8eab61d3adac5a2",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/iplayground/SessionData",
       "state" : {
-        "revision" : "21edf250d668ffe45fae924dee96dc7556053607",
-        "version" : "2025.1.1"
+        "revision" : "1966b0488bcea6039ac85d233748e655ffce37df",
+        "version" : "2025.1.2"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "bc92c4b27f9a84bfb498cdbfdf35d5a357e9161f",
-        "version" : "1.5.6"
+        "revision" : "9810c8d6c2914de251e072312f01d3bf80071852",
+        "version" : "1.7.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
-        "version" : "1.9.2"
+        "revision" : "a501eebe552fd23691c560adf474fca2169ad8aa",
+        "version" : "1.9.4"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
-        "version" : "1.1.0"
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "db6bc9dbfed001f21e6728fd36413d9342c235b4",
-        "version" : "2.3.0"
+        "revision" : "4e89284c1966538109dc783497405bc680e9bc96",
+        "version" : "2.4.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "8d52279b9809ef27eabe7d5420f03734528f19da",
-        "version" : "1.4.1"
+        "revision" : "7d3509c7f4de78ad3eb3d804e036fb62e3585141",
+        "version" : "2.0.5"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "974e51b3612317ba5883a73dc9fd9e2409a11f2d",
-        "version" : "1.1.1"
+        "revision" : "530c98ac2c3e393615616bd6d8fc604600c99f6f",
+        "version" : "2.7.2"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
-        "version" : "1.4.3"
+        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
+        "version" : "1.6.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let appName = "App"
 let sessionData = SourceControlDependency(
   package: .package(
     url: "https://github.com/iplayground/SessionData",
-    exact: "2025.1.1"
+    exact: "2025.1.2"
   ),
   productName: "SessionData"
 )

--- a/Sources/Features/CommunityFeature.swift
+++ b/Sources/Features/CommunityFeature.swift
@@ -67,7 +67,7 @@ package struct CommunityFeature {
         return .none
 
       case .tapSpeaker(let speaker):
-        state.path.append(.speaker(.init(speaker: speaker)))
+        state.path.append(.speaker(.init(speaker: speaker, hackMDURL: nil)))
         return .none
       }
     }

--- a/Sources/Features/SpeakerFeature.swift
+++ b/Sources/Features/SpeakerFeature.swift
@@ -14,9 +14,11 @@ package struct SpeakerFeature {
   @ObservableState
   package struct State: Equatable {
     package var speaker: Speaker
+    package var hackMDURL: URL?
 
-    package init(speaker: Speaker) {
+    package init(speaker: Speaker, hackMDURL: URL?) {
       self.speaker = speaker
+      self.hackMDURL = hackMDURL
     }
   }
 
@@ -30,6 +32,7 @@ package struct SpeakerFeature {
       case task
       case tapURL(URL)
       case tapCopyURL(URL)
+      case tapHackMDButton
     }
   }
 
@@ -58,6 +61,14 @@ package struct SpeakerFeature {
         return .run { _ in
           @Dependency(\.pasteboardClient) var pasteboardClient
           pasteboardClient.copy(url.absoluteString)
+        }
+      case .tapHackMDButton:
+        guard let hackMDURL = state.hackMDURL else {
+          return .none
+        }
+        return .run { _ in
+          @Dependency(\.openURL) var openURL
+          await openURL(hackMDURL)
         }
       }
     }

--- a/Sources/Features/TodayFeature.swift
+++ b/Sources/Features/TodayFeature.swift
@@ -75,7 +75,7 @@ package struct TodayFeature {
     case binding(BindingAction<State>)
     case path(StackActionOf<Path>)
     case view(ViewAction)
-    case navigateToSpeaker(Speaker)
+    case navigateToSpeaker(Speaker, hackMDURL: URL?)
 
     @CasePathable
     package enum ViewAction: Equatable {
@@ -176,19 +176,20 @@ package struct TodayFeature {
         }
         return .run { [speakers = state.speakers] send in
           if let speaker = speakers[id: speakerID] {
-            await send(.navigateToSpeaker(speaker))
+            await send(.navigateToSpeaker(speaker, hackMDURL: session.hackMDURL))
           } else {
             @Dependency(\.iPlaygroundDataClient) var client
             guard let speaker = try await client.fetchSpeakers(.remote)[id: speakerID] else {
               return
             }
-            await send(.navigateToSpeaker(speaker))
+            await send(.navigateToSpeaker(speaker, hackMDURL: session.hackMDURL))
           }
         }
       }
 
-    case let .navigateToSpeaker(speaker):
-      state.path.append(.speaker(.init(speaker: speaker)))
+    case let .navigateToSpeaker(speaker, hackMDURL: hackMDURL):
+      state.path.append(
+        .speaker(.init(speaker: speaker, hackMDURL: hackMDURL)))
       return .none
     }
   }

--- a/Sources/Models/SessionWrapper.swift
+++ b/Sources/Models/SessionWrapper.swift
@@ -10,6 +10,7 @@ package struct SessionWrapper: Identifiable, Equatable {
   package let speakerID: Speaker.ID?
   package let tags: String?
   package let description: String?
+  package let hackMDURL: URL?
 
   package init(
     date: Date,
@@ -18,7 +19,8 @@ package struct SessionWrapper: Identifiable, Equatable {
     speaker: String,
     speakerID: Speaker.ID?,
     tags: String?,
-    description: String?
+    description: String?,
+    hackMDURL: URL?
   ) {
     self.timeRange = timeRange
     self.dateInterval = Self.parseDateInterval(from: timeRange, baseDate: date)
@@ -27,6 +29,7 @@ package struct SessionWrapper: Identifiable, Equatable {
     self.speakerID = speakerID
     self.tags = tags
     self.description = description
+    self.hackMDURL = hackMDURL
   }
 
   package init(date: Date, session: Session) {
@@ -37,6 +40,7 @@ package struct SessionWrapper: Identifiable, Equatable {
     self.speakerID = session.speakerID
     self.tags = session.tags.isEmpty ? nil : session.tags.joined(separator: " · ")
     self.description = session.description.isEmpty ? nil : session.description
+    self.hackMDURL = session.hackMD
   }
 
   package init(session: Session) {
@@ -47,6 +51,7 @@ package struct SessionWrapper: Identifiable, Equatable {
     self.speakerID = session.speakerID
     self.tags = session.tags.isEmpty ? nil : session.tags.joined(separator: " · ")
     self.description = session.description.isEmpty ? nil : session.description
+    self.hackMDURL = session.hackMD
   }
 
   package init(
@@ -55,7 +60,8 @@ package struct SessionWrapper: Identifiable, Equatable {
     speaker: String,
     speakerID: Speaker.ID?,
     tags: String?,
-    description: String?
+    description: String?,
+    hackMDURL: URL?
   ) {
     self.timeRange = timeRange
     self.dateInterval = nil
@@ -64,6 +70,7 @@ package struct SessionWrapper: Identifiable, Equatable {
     self.speakerID = speakerID
     self.tags = tags
     self.description = description
+    self.hackMDURL = hackMDURL
   }
 
   private static func parseDateInterval(from timeRange: String, baseDate: Date) -> DateInterval? {

--- a/Sources/Views/AboutView.swift
+++ b/Sources/Views/AboutView.swift
@@ -186,7 +186,7 @@ package struct AboutView: View {
       if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
         let settingsLink = Models.Link(
           id: "licensePlist",
-          title: "Acknowledgements",
+          title: String(localized: "Open Source Licenses", bundle: .module),
           url: settingsURL,
           icon: "list.bullet.rectangle",
           type: .appInfo
@@ -214,9 +214,9 @@ package struct AboutView: View {
       label: {
         HStack {
           if let iconName = link.icon {
-            Label(link.title, systemImage: iconName)
+            Label(link.localizedTitle, systemImage: iconName)
           } else {
-            Text(link.title)
+            Text(link.localizedTitle)
           }
           Spacer()
           Image(systemName: "arrow.up.right.square")
@@ -255,6 +255,51 @@ package struct AboutView: View {
   private var appInfoLinks: [Models.Link] {
     store.links.filter { link in
       link.type == .appInfo
+    }
+  }
+}
+
+// Link title localized by ID
+
+extension Models.Link {
+  var localizedTitle: String {
+    switch id {
+    case "website":
+      return String(localized: "Website", bundle: .module)
+    case "coc":
+      return String(localized: "Code of Conduct", bundle: .module)
+    case "hackmd":
+      return String(localized: "HackMD", bundle: .module)
+    case "newsletter":
+      return String(localized: "Newsletter", bundle: .module)
+    case "youtube":
+      return "YouTube"
+    case "discord":
+      return "Discord"
+    case "twitter":
+      return "Twitter (X)"
+    case "threads":
+      return "Threads"
+    case "mastodon":
+      return "Mastodon"
+    case "facebook":
+      return "Facebook"
+    case "app-source":
+      return "iplayground-app-2025"
+    case "session-data-source":
+      return "SessionData"
+    case "app-store":
+      return "App Store"
+    case "privacy-policy":
+      return String(localized: "Privacy Policy", bundle: .module)
+    case "kktix":
+      return String(localized: "KKTIX", bundle: .module)
+    case "notice":
+      return String(localized: "Notice", bundle: .module)
+    case "lightning-talk":
+      return String(localized: "Lightning Talk", bundle: .module)
+    default:
+      return title
     }
   }
 }

--- a/Sources/Views/CommunityView.swift
+++ b/Sources/Views/CommunityView.swift
@@ -30,6 +30,9 @@ struct CommunityView: View {
   private var rootView: some View {
     VStack(spacing: .zero) {
       tabs
+        .background {
+          store.selectedTab.backgroundColor
+        }
 
       switch store.selectedTab {
       case .sponsor:
@@ -42,6 +45,8 @@ struct CommunityView: View {
     }
     .navigationTitle(String(localized: "社群", bundle: .module))
     .navigationBarTitleDisplayMode(.inline)
+    .toolbarBackground(.visible, for: .navigationBar)
+    .toolbarBackground(store.selectedTab.backgroundColor, for: .navigationBar)
     .task {
       send(.task)
     }
@@ -265,6 +270,17 @@ extension CommunityFeature.Tab {
       return "贊助商"
     case .staff:
       return "工作人員"
+    }
+  }
+
+  var backgroundColor: Color {
+    switch self {
+    case .speaker:
+      return Color(.iPlaygroundBlueBackground)
+    case .sponsor:
+      return Color(.iPlaygroundYellowBackground)
+    case .staff:
+      return Color(.iPlaygroundPinkBackground)
     }
   }
 }

--- a/Sources/Views/CommunityView.swift
+++ b/Sources/Views/CommunityView.swift
@@ -28,7 +28,7 @@ struct CommunityView: View {
 
   @ViewBuilder
   private var rootView: some View {
-    VStack {
+    VStack(spacing: .zero) {
       tabs
 
       switch store.selectedTab {
@@ -57,7 +57,7 @@ struct CommunityView: View {
     }
     .pickerStyle(.segmented)
     .padding(.horizontal)
-    .padding(.bottom, 8)
+    .padding(.vertical, 8)
   }
 
   @ViewBuilder
@@ -236,7 +236,7 @@ struct CommunityView: View {
       }
     }
     .listStyle(.plain)
-    .contentMargins(.vertical, -4, for: .scrollIndicators)
+    .contentMargins(.bottom, -4, for: .scrollIndicators)
   }
 
   @ViewBuilder
@@ -252,7 +252,7 @@ struct CommunityView: View {
       }
     }
     .listStyle(.plain)
-    .contentMargins(.vertical, -4, for: .scrollIndicators)
+    .contentMargins(.bottom, -4, for: .scrollIndicators)
   }
 }
 

--- a/Sources/Views/CommunityView.swift
+++ b/Sources/Views/CommunityView.swift
@@ -37,6 +37,7 @@ struct CommunityView: View {
       switch store.selectedTab {
       case .sponsor:
         sponsorsView
+          .environment(\.colorScheme, .light)
       case .speaker:
         speakersView
       case .staff:

--- a/Sources/Views/MyView.swift
+++ b/Sources/Views/MyView.swift
@@ -45,9 +45,9 @@ struct MyView: View {
       label: {
         HStack {
           if let iconName = link.icon {
-            Label(link.title, systemImage: iconName)
+            Label(link.localizedTitle, systemImage: iconName)
           } else {
-            Text(link.title)
+            Text(link.localizedTitle)
           }
           Spacer()
           Image(systemName: "arrow.up.right.square")

--- a/Sources/Views/Resources/Colors.xcassets/iPlaygroundBlueBackground.colorset/Contents.json
+++ b/Sources/Views/Resources/Colors.xcassets/iPlaygroundBlueBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xDF",
-          "green" : "0x47",
-          "red" : "0x3B"
+          "blue" : "0xEF",
+          "green" : "0x57",
+          "red" : "0x4B"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0x85",
-          "red" : "0x7B"
+          "blue" : "0x70",
+          "green" : "0x36",
+          "red" : "0x2D"
         }
       },
       "idiom" : "universal"

--- a/Sources/Views/Resources/Colors.xcassets/iPlaygroundPink.colorset/Contents.json
+++ b/Sources/Views/Resources/Colors.xcassets/iPlaygroundPink.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xA7",
-          "green" : "0x5F",
-          "red" : "0xEE"
+          "blue" : "0x9A",
+          "green" : "0x45",
+          "red" : "0xD4"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xAA",
-          "green" : "0x73",
-          "red" : "0xF7"
+          "blue" : "0xBD",
+          "green" : "0x79",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/Sources/Views/Resources/Colors.xcassets/iPlaygroundPinkBackground.colorset/Contents.json
+++ b/Sources/Views/Resources/Colors.xcassets/iPlaygroundPinkBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xDF",
-          "green" : "0x47",
-          "red" : "0x3B"
+          "blue" : "0xA7",
+          "green" : "0x5F",
+          "red" : "0xEE"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0x85",
-          "red" : "0x7B"
+          "blue" : "0x5E",
+          "green" : "0x3A",
+          "red" : "0x7A"
         }
       },
       "idiom" : "universal"

--- a/Sources/Views/Resources/Colors.xcassets/iPlaygroundYellow.colorset/Contents.json
+++ b/Sources/Views/Resources/Colors.xcassets/iPlaygroundYellow.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x01",
-          "green" : "0xB8",
-          "red" : "0xF8"
+          "blue" : "0x00",
+          "green" : "0xA5",
+          "red" : "0xE6"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x38",
-          "green" : "0xBC",
-          "red" : "0xFC"
+          "blue" : "0x40",
+          "green" : "0xD0",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/Sources/Views/Resources/Colors.xcassets/iPlaygroundYellowBackground.colorset/Contents.json
+++ b/Sources/Views/Resources/Colors.xcassets/iPlaygroundYellowBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xDF",
-          "green" : "0x47",
-          "red" : "0x3B"
+          "blue" : "0x01",
+          "green" : "0xB8",
+          "red" : "0xF8"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0x85",
-          "red" : "0x7B"
+          "blue" : "0x00",
+          "green" : "0x6B",
+          "red" : "0x8B"
         }
       },
       "idiom" : "universal"

--- a/Sources/Views/Resources/Localizable.xcstrings
+++ b/Sources/Views/Resources/Localizable.xcstrings
@@ -4,6 +4,17 @@
     "" : {
       "shouldTranslate" : false
     },
+    "App Store" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Store"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
     "App 資訊" : {
       "localizations" : {
         "en" : {
@@ -16,6 +27,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アプリ情報"
+          }
+        }
+      }
+    },
+    "Code of Conduct" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code of Conduct"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行動規範"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行為守則"
+          }
+        }
+      }
+    },
+    "HackMD" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HackMD"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HackMD 共有ノート"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HackMD 共筆目錄"
           }
         }
       }
@@ -38,6 +93,148 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "iPlayground 2025 倒數中：%@"
+          }
+        }
+      }
+    },
+    "KKTIX" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "My Ticket(KKTIX)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マイチケット(KKTIX)"
+          }
+        }
+      }
+    },
+    "Lightning Talk" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lightning Talk"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライトニングトーク"
+          }
+        }
+      }
+    },
+    "Newsletter" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Newsletter"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ニュースレター"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電子報"
+          }
+        }
+      }
+    },
+    "Notice" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notice"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "事前通知"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行前通知"
+          }
+        }
+      }
+    },
+    "Open Source Licenses" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Source Licenses"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オープンソースライセンス"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開源協議"
+          }
+        }
+      }
+    },
+    "Privacy Policy" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy Policy"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライバシーポリシー"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱私權政策"
+          }
+        }
+      }
+    },
+    "Website" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Official Website"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公式ウェブサイト"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "官方網站"
           }
         }
       }

--- a/Sources/Views/Resources/Localizable.xcstrings
+++ b/Sources/Views/Resources/Localizable.xcstrings
@@ -25,13 +25,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Countdown: %@"
+            "value" : "iPlayground 2025 Countdown: %@"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "カウントダウン: %@"
+            "value" : "iPlayground 2025 カウントダウン: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iPlayground 2025 倒數中：%@"
           }
         }
       }

--- a/Sources/Views/SpeakerView.swift
+++ b/Sources/Views/SpeakerView.swift
@@ -31,6 +31,17 @@ struct SpeakerView: View {
     .contentMargins(.top, .zero)
     .navigationTitle("講者")
     .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      if store.hackMDURL != nil {
+        ToolbarItem(placement: .topBarTrailing) {
+          Button(action: {
+            send(.tapHackMDButton)
+          }) {
+            Label("HackMD", systemImage: "note.text")
+          }
+        }
+      }
+    }
   }
 
   // MARK: - Child Views
@@ -178,7 +189,7 @@ struct SpeakerView: View {
             threads: URL(string: "https://www.threads.net")!,
             x: URL(string: "https://www.x.com")!,
             ig: URL(string: "https://www.instagram.com")!
-          )
+          ), hackMDURL: URL(string: "https://hackmd.io/@iPlayground/S1rVR6Zugl")
         ),
         reducer: { SpeakerFeature() }
       )

--- a/Tests/FeaturesTests/CommunityFeatureTests.swift
+++ b/Tests/FeaturesTests/CommunityFeatureTests.swift
@@ -18,14 +18,14 @@ final class CommunityFeatureTests: XCTestCase {
     }
 
     await store.send(\.view.tapSpeaker, speaker) {
-      $0.path.append(.speaker(SpeakerFeature.State(speaker: speaker)))
+      $0.path.append(.speaker(SpeakerFeature.State(speaker: speaker, hackMDURL: nil)))
     }
   }
 
   func testPathNavigation() async {
     let speaker = createMockSpeaker()
     var initialState = CommunityFeature.State()
-    initialState.path.append(.speaker(SpeakerFeature.State(speaker: speaker)))
+    initialState.path.append(.speaker(SpeakerFeature.State(speaker: speaker, hackMDURL: nil)))
 
     let store = TestStore(initialState: initialState) {
       CommunityFeature()

--- a/Tests/FeaturesTests/SpeakerFeatureTests.swift
+++ b/Tests/FeaturesTests/SpeakerFeatureTests.swift
@@ -12,18 +12,34 @@ final class SpeakerFeatureTests: XCTestCase {
 
   func testInitialState() async {
     let speaker = createMockSpeaker()
-    let store = TestStore(initialState: SpeakerFeature.State(speaker: speaker)) {
+    let store = TestStore(initialState: SpeakerFeature.State(speaker: speaker, hackMDURL: nil)) {
       SpeakerFeature()
     }
 
     store.assert {
       $0.speaker = speaker
+      $0.hackMDURL = nil
+    }
+  }
+
+  func testInitialStateWithHackMDURL() async {
+    let speaker = createMockSpeaker()
+    let hackMDURL = URL(string: "https://hackmd.io/test")!
+    let store = TestStore(
+      initialState: SpeakerFeature.State(speaker: speaker, hackMDURL: hackMDURL)
+    ) {
+      SpeakerFeature()
+    }
+
+    store.assert {
+      $0.speaker = speaker
+      $0.hackMDURL = hackMDURL
     }
   }
 
   func testTaskAction() async {
     let speaker = createMockSpeaker()
-    let store = TestStore(initialState: SpeakerFeature.State(speaker: speaker)) {
+    let store = TestStore(initialState: SpeakerFeature.State(speaker: speaker, hackMDURL: nil)) {
       SpeakerFeature()
     }
 
@@ -34,7 +50,7 @@ final class SpeakerFeatureTests: XCTestCase {
     let speaker = createMockSpeaker()
     let testURL = URL(string: "https://example.com")!
 
-    let store = TestStore(initialState: SpeakerFeature.State(speaker: speaker)) {
+    let store = TestStore(initialState: SpeakerFeature.State(speaker: speaker, hackMDURL: nil)) {
       SpeakerFeature()
     } withDependencies: {
       $0.openURL = OpenURLEffect { url in
@@ -50,7 +66,7 @@ final class SpeakerFeatureTests: XCTestCase {
     let speaker = createMockSpeaker()
     let testURL = URL(string: "https://example.com")!
 
-    let store = TestStore(initialState: SpeakerFeature.State(speaker: speaker)) {
+    let store = TestStore(initialState: SpeakerFeature.State(speaker: speaker, hackMDURL: nil)) {
       SpeakerFeature()
     } withDependencies: {
       $0.pasteboardClient.copy = { string in
@@ -59,6 +75,34 @@ final class SpeakerFeatureTests: XCTestCase {
     }
 
     await store.send(\.view.tapCopyURL, testURL)
+  }
+
+  func testTapHackMDButtonWithURL() async {
+    let speaker = createMockSpeaker()
+    let hackMDURL = URL(string: "https://hackmd.io/@iPlayground/test")!
+
+    let store = TestStore(
+      initialState: SpeakerFeature.State(speaker: speaker, hackMDURL: hackMDURL)
+    ) {
+      SpeakerFeature()
+    } withDependencies: {
+      $0.openURL = OpenURLEffect { url in
+        XCTAssertEqual(url, hackMDURL)
+        return true
+      }
+    }
+
+    await store.send(\.view.tapHackMDButton)
+  }
+
+  func testTapHackMDButtonWithoutURL() async {
+    let speaker = createMockSpeaker()
+
+    let store = TestStore(initialState: SpeakerFeature.State(speaker: speaker, hackMDURL: nil)) {
+      SpeakerFeature()
+    }
+
+    await store.send(\.view.tapHackMDButton)
   }
 
   // MARK: - Helper Methods

--- a/Tests/FeaturesTests/TodayFeatureStateTests.swift
+++ b/Tests/FeaturesTests/TodayFeatureStateTests.swift
@@ -245,7 +245,8 @@ final class TodayFeatureStateTests: XCTestCase {
       speaker: speaker,
       speakerID: 0,
       tags: nil,
-      description: "Test description"
+      description: "Test description",
+      hackMDURL: nil
     )
   }
 

--- a/Tests/FeaturesTests/TodayFeatureTests.swift
+++ b/Tests/FeaturesTests/TodayFeatureTests.swift
@@ -213,7 +213,8 @@ final class TodayFeatureTests: XCTestCase {
         speaker: speaker,
         speakerID: 0,
         tags: nil,
-        description: "Test description"
+        description: "Test description",
+        hackMDURL: nil
       )
     }
   }

--- a/Tests/ModelsTests/SessionWrapperTests.swift
+++ b/Tests/ModelsTests/SessionWrapperTests.swift
@@ -16,7 +16,8 @@ struct SessionWrapperTests {
       speaker: "Test Speaker",
       speakerID: 0,
       tags: nil,
-      description: nil
+      description: nil,
+      hackMDURL: nil
     )
 
     #expect(wrapper.dateInterval != nil)
@@ -54,7 +55,8 @@ struct SessionWrapperTests {
       speaker: "Test Speaker",
       speakerID: 0,
       tags: nil,
-      description: nil
+      description: nil,
+      hackMDURL: nil
     )
 
     #expect(wrapper.dateInterval != nil)
@@ -103,7 +105,8 @@ struct SessionWrapperTests {
         speaker: "Test Speaker",
         speakerID: 0,
         tags: nil,
-        description: nil
+        description: nil,
+        hackMDURL: nil
       )
 
       #expect(wrapper.dateInterval == nil, "Expected nil for invalid format: \(invalidFormat)")
@@ -154,7 +157,8 @@ struct SessionWrapperTests {
         speaker: "Test Speaker",
         speakerID: 0,
         tags: nil,
-        description: nil
+        description: nil,
+        hackMDURL: nil
       )
 
       #expect(wrapper.dateInterval != nil, "Expected successful parsing for format: \(format)")
@@ -184,7 +188,8 @@ struct SessionWrapperTests {
       speaker: "Night Owl",
       speakerID: 0,
       tags: nil,
-      description: nil
+      description: nil,
+      hackMDURL: nil
     )
 
     #expect(wrapper.dateInterval != nil)
@@ -216,17 +221,72 @@ struct SessionWrapperTests {
     return calendar.date(from: components)!
   }
 
-  private func createMockSession(time: String) -> Session {
-    let jsonString = """
-      {
-        "time": "\(time)",
-        "title": "Mock Session",
-        "tags": ["test"],
-        "speaker": "Mock Speaker",
-        "speakerID": 0,
-        "description": "Mock Description"
-      }
-      """
+  @Test("Initialize SessionWrapper with hackMD URL")
+  func initializeSessionWrapperWithHackMDURL() {
+    let hackMDURL = URL(string: "https://hackmd.io/@iPlayground/test")!
+    let date = createDate(year: 2025, month: 8, day: 30)
+
+    let wrapper = SessionWrapper(
+      date: date,
+      timeRange: "11:30 - 11:50",
+      title: "Test Session",
+      speaker: "Test Speaker",
+      speakerID: 0,
+      tags: nil,
+      description: nil,
+      hackMDURL: hackMDURL
+    )
+
+    #expect(wrapper.hackMDURL == hackMDURL)
+  }
+
+  @Test("Initialize SessionWrapper from Session with hackMD")
+  func initializeFromSessionWithHackMD() {
+    let hackMDURL = URL(string: "https://hackmd.io/@iPlayground/session123")!
+    let session = createMockSession(time: "14:15 - 15:05", hackMD: hackMDURL)
+    let date = createDate(year: 2025, month: 8, day: 30)
+
+    let wrapper = SessionWrapper(date: date, session: session)
+
+    #expect(wrapper.hackMDURL == hackMDURL)
+  }
+
+  @Test("Initialize SessionWrapper from Session without hackMD")
+  func initializeFromSessionWithoutHackMD() {
+    let session = createMockSession(time: "14:15 - 15:05", hackMD: nil)
+    let date = createDate(year: 2025, month: 8, day: 30)
+
+    let wrapper = SessionWrapper(date: date, session: session)
+
+    #expect(wrapper.hackMDURL == nil)
+  }
+
+  private func createMockSession(time: String, hackMD: URL? = nil) -> Session {
+    let jsonString: String
+    if let hackMD = hackMD {
+      jsonString = """
+        {
+          "time": "\(time)",
+          "title": "Mock Session",
+          "tags": ["test"],
+          "speaker": "Mock Speaker",
+          "speakerID": 0,
+          "description": "Mock Description",
+          "hackMD": "\(hackMD.absoluteString)"
+        }
+        """
+    } else {
+      jsonString = """
+        {
+          "time": "\(time)",
+          "title": "Mock Session",
+          "tags": ["test"],
+          "speaker": "Mock Speaker",
+          "speakerID": 0,
+          "description": "Mock Description"
+        }
+        """
+    }
 
     let jsonData = jsonString.data(using: .utf8)!
     let decoder = JSONDecoder()

--- a/iPlayground/iPlayground.xcodeproj/project.pbxproj
+++ b/iPlayground/iPlayground.xcodeproj/project.pbxproj
@@ -300,6 +300,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MARKETING_VERSION = 2025.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ethanhuang13.iPlayground;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -341,6 +342,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MARKETING_VERSION = 2025.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ethanhuang13.iPlayground;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/iPlayground/iPlayground.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iPlayground/iPlayground.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7000bfdd142c92db698957e84c2e17c94432db50e44fa5ae8dc84b1bc81f5f6b",
+  "originHash" : "0caf1cf78a0a2c9a5351dec94950bb99eec9c60d306c53bee8eab61d3adac5a2",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/iplayground/SessionData",
       "state" : {
-        "revision" : "21edf250d668ffe45fae924dee96dc7556053607",
-        "version" : "2025.1.1"
+        "revision" : "1966b0488bcea6039ac85d233748e655ffce37df",
+        "version" : "2025.1.2"
       }
     },
     {


### PR DESCRIPTION
## Summary
• Upgraded SessionData dependency from v2025.1.1 to v2025.1.2 with latest session data
• Added HackMD URL integration to SessionWrapper and SpeakerFeature for accessing shared notes
• Enhanced CommunityView with colored navigation bar backgrounds matching brand theme colors
• Updated brand colors for better consistency across light/dark themes with new background variants
• Added comprehensive localized strings for link titles in AboutView and MyView
• Added HackMD toolbar button to SpeakerView when HackMD URL is available
• Updated all package dependencies to their latest stable versions

## Test plan
- [x] All existing tests pass
- [x] Swift formatting applied
- [x] UI displays correctly with new color scheme
- [x] HackMD button appears and functions when URL is available
- [x] Localized strings display correctly across all supported languages

## Demo Video

- Session HackMD
- Light mode for sponsors list
- Localized link title

https://github.com/user-attachments/assets/96d8d97f-ef9a-49c4-82d3-b68fe8710e17

🤖 Generated with [Claude Code](https://claude.ai/code)