### PR TITLE
Update default Chinese mapping to Traditional Chinese and clear chat list on language change

### DIFF
--- a/Sources/Features/LiveTranslationFeature.swift
+++ b/Sources/Features/LiveTranslationFeature.swift
@@ -392,8 +392,9 @@ package struct LiveTranslationFeature {
       case let .changeLanguage(langCode):
         state.selectedLangCode = langCode
         state.isShowingLanguageSheet = false
-
-        let existingChatItems = state.chatList
+        
+        // Clear chat list when changing language
+        state.chatList = []
 
         return .run { send in
           @Dependency(\.liveTranslationClient) var client
@@ -406,10 +407,8 @@ package struct LiveTranslationFeature {
             logger.error("Failed to load language set for \(langCode): \(error)")
           }
 
-          // Request translations for existing chat items
-          if !existingChatItems.isEmpty {
-            await send(.requestTranslation(existingChatItems))
-          }
+          // Reconnect stream to get fresh data
+          await send(.view(.connectStream))
         }
 
       case .showLanguageSheet:

--- a/Sources/Features/LiveTranslationFeature.swift
+++ b/Sources/Features/LiveTranslationFeature.swift
@@ -21,7 +21,7 @@ package struct LiveTranslationFeature {
     "zh-Hant-MO": "zh-TW",
     "zh-Hans": "zh-CN",  // Simplified Chinese
     "zh-Hans-CN": "zh-CN",
-    "zh": "zh-CN",  // Default Chinese maps to Simplified
+    "zh": "zh-TW",  // Default Chinese maps to Traditional Chinese
 
     // Cantonese
     "yue": "yue",
@@ -392,7 +392,7 @@ package struct LiveTranslationFeature {
       case let .changeLanguage(langCode):
         state.selectedLangCode = langCode
         state.isShowingLanguageSheet = false
-        
+
         // Clear chat list when changing language
         state.chatList = []
 

--- a/Sources/Views/LiveTranslationView.swift
+++ b/Sources/Views/LiveTranslationView.swift
@@ -119,6 +119,8 @@ package struct LiveTranslationView: View {
             .multilineTextAlignment(.leading)
             .padding()
         }
+
+        Text(verbatim: "\n\n\n\n\n\n")
       }
     }
     .environment(\.layoutDirection, isRTL ? .rightToLeft : .leftToRight)

--- a/Sources/Views/LiveTranslationView.swift
+++ b/Sources/Views/LiveTranslationView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 @ViewAction(for: LiveTranslationFeature.self)
 package struct LiveTranslationView: View {
   @Bindable package var store: StoreOf<LiveTranslationFeature>
+  @State private var autoScroll = true
+  private let messageBottomID = "_messageBottom"
 
   package init(store: StoreOf<LiveTranslationFeature>) {
     self.store = store
@@ -111,19 +113,46 @@ package struct LiveTranslationView: View {
 
   @ViewBuilder
   private var messageList: some View {
-    ScrollView {
-      LazyVStack {
-        ForEach(store.chatList) { item in
-          Text(item.translatedText ?? item.text)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .multilineTextAlignment(.leading)
-            .padding()
+    ScrollViewReader { proxy in
+      ScrollView {
+        LazyVStack {
+          ForEach(store.chatList) { item in
+            Text(item.translatedText ?? item.text)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .multilineTextAlignment(.leading)
+              .padding()
+          }
         }
-
         Text(verbatim: "\n\n\n\n\n\n")
+          .id(messageBottomID)
+      }
+      .environment(\.layoutDirection, isRTL ? .rightToLeft : .leftToRight)
+      .onChange(of: store.chatList) { oldValue, newValue in
+        autoScrollToBottomIfNeeded(proxy: proxy)
+      }
+      .overlay(alignment: .bottom) {
+        Button(
+          action: {
+            autoScroll.toggle()
+            autoScrollToBottomIfNeeded(proxy: proxy)
+          },
+          label: {
+            Image(systemName: autoScroll ? "arrow.down.circle.fill" : "arrow.down.circle")
+              .imageScale(.large)
+              .font(.largeTitle)
+              .padding()
+          }
+        )
       }
     }
-    .environment(\.layoutDirection, isRTL ? .rightToLeft : .leftToRight)
+  }
+
+  private func autoScrollToBottomIfNeeded(proxy: ScrollViewProxy) {
+    if autoScroll {
+      withAnimation(.spring) {
+        proxy.scrollTo(messageBottomID, anchor: .bottom)
+      }
+    }
   }
 
   @ViewBuilder

--- a/Tests/FeaturesTests/LiveTranslationFeatureTests.swift
+++ b/Tests/FeaturesTests/LiveTranslationFeatureTests.swift
@@ -194,7 +194,7 @@ final class LiveTranslationFeatureTests: XCTestCase {
     await store.send(.view(.changeLanguage("ja"))) {
       $0.selectedLangCode = "ja"
       $0.isShowingLanguageSheet = false
-      $0.chatList = [] // Chat list should be cleared
+      $0.chatList = []  // Chat list should be cleared
     }
 
     await store.receive(.langSetLoaded(LangSet(data: ["en": "English", "ja": "日本語"]))) {
@@ -204,7 +204,7 @@ final class LiveTranslationFeatureTests: XCTestCase {
 
     // Should connect stream to get fresh data
     await store.receive(.view(.connectStream))
-    
+
     // Cleanup
     await store.send(.view(.disconnectStream))
     await store.finish()
@@ -240,7 +240,7 @@ final class LiveTranslationFeatureTests: XCTestCase {
     await store.send(.view(.changeLanguage("ja"))) {
       $0.selectedLangCode = "ja"
       $0.isShowingLanguageSheet = false
-      $0.chatList = [] // Chat list should be cleared
+      $0.chatList = []  // Chat list should be cleared
     }
 
     await store.receive(.langSetLoaded(LangSet(data: ["en": "English", "ja": "日本語"]))) {
@@ -255,7 +255,7 @@ final class LiveTranslationFeatureTests: XCTestCase {
     await store.send(.view(.changeLanguage("zh"))) {
       $0.selectedLangCode = "zh"
       $0.isShowingLanguageSheet = false
-      $0.chatList = [] // Chat list should be cleared again
+      $0.chatList = []  // Chat list should be cleared again
     }
 
     await store.receive(.langSetLoaded(LangSet(data: ["en": "English", "zh": "中文"]))) {
@@ -270,7 +270,7 @@ final class LiveTranslationFeatureTests: XCTestCase {
     await store.send(.view(.changeLanguage("ko"))) {
       $0.selectedLangCode = "ko"
       $0.isShowingLanguageSheet = false
-      $0.chatList = [] // Chat list should be cleared again
+      $0.chatList = []  // Chat list should be cleared again
     }
 
     await store.receive(.langSetLoaded(LangSet(data: ["en": "English", "ko": "한국어"]))) {
@@ -280,10 +280,10 @@ final class LiveTranslationFeatureTests: XCTestCase {
 
     // Should connect stream again
     await store.receive(.view(.connectStream))
-    
+
     // Cleanup: disconnect the stream to end the test properly
     await store.send(.view(.disconnectStream))
-    
+
     await store.finish()
   }
 

--- a/Tests/FeaturesTests/LiveTranslationFeatureTests.swift
+++ b/Tests/FeaturesTests/LiveTranslationFeatureTests.swift
@@ -186,20 +186,105 @@ final class LiveTranslationFeatureTests: XCTestCase {
           return LangSet(data: ["en": "English", "zh": "中文"])
         }
       }
-      $0.liveTranslationClient.requestBatchTranslation = { _ in }
+      $0.liveTranslationClient.chatConnection = { _ in
+        AsyncThrowingStream { _ in }
+      }
     }
 
-    await store.send(\.view, .changeLanguage("ja")) {
+    await store.send(.view(.changeLanguage("ja"))) {
       $0.selectedLangCode = "ja"
       $0.isShowingLanguageSheet = false
+      $0.chatList = [] // Chat list should be cleared
     }
 
-    await store.receive(\.langSetLoaded, LangSet(data: ["en": "English", "ja": "日本語"])) {
+    await store.receive(.langSetLoaded(LangSet(data: ["en": "English", "ja": "日本語"]))) {
       $0.langSet = LangSet(data: ["en": "English", "ja": "日本語"])
       $0.hasLoadedLangSet = true
     }
 
-    // Note: requestTranslation is not called when chatList is empty
+    // Should connect stream to get fresh data
+    await store.receive(.view(.connectStream))
+    
+    // Cleanup
+    await store.send(.view(.disconnectStream))
+    await store.finish()
+  }
+
+  func testChangeLanguageMultipleTimes() async {
+    var initialState = LiveTranslationFeature.State()
+    initialState.isConnected = true  // Simulate being connected
+
+    let store = TestStore(
+      initialState: initialState,
+      reducer: { LiveTranslationFeature() }
+    ) {
+      $0.liveTranslationClient.getLangSet = { langCode in
+        switch langCode {
+        case "ja":
+          return LangSet(data: ["en": "English", "ja": "日本語"])
+        case "zh":
+          return LangSet(data: ["en": "English", "zh": "中文"])
+        case "ko":
+          return LangSet(data: ["en": "English", "ko": "한국어"])
+        default:
+          return LangSet(data: ["en": "English"])
+        }
+      }
+      $0.liveTranslationClient.requestBatchTranslation = { _ in }
+      $0.liveTranslationClient.chatConnection = { _ in
+        AsyncThrowingStream { _ in }
+      }
+    }
+
+    // First language change
+    await store.send(.view(.changeLanguage("ja"))) {
+      $0.selectedLangCode = "ja"
+      $0.isShowingLanguageSheet = false
+      $0.chatList = [] // Chat list should be cleared
+    }
+
+    await store.receive(.langSetLoaded(LangSet(data: ["en": "English", "ja": "日本語"]))) {
+      $0.langSet = LangSet(data: ["en": "English", "ja": "日本語"])
+      $0.hasLoadedLangSet = true
+    }
+
+    // Should connect stream to get fresh data
+    await store.receive(.view(.connectStream))
+
+    // Second language change
+    await store.send(.view(.changeLanguage("zh"))) {
+      $0.selectedLangCode = "zh"
+      $0.isShowingLanguageSheet = false
+      $0.chatList = [] // Chat list should be cleared again
+    }
+
+    await store.receive(.langSetLoaded(LangSet(data: ["en": "English", "zh": "中文"]))) {
+      $0.langSet = LangSet(data: ["en": "English", "zh": "中文"])
+      $0.hasLoadedLangSet = true
+    }
+
+    // Should connect stream again
+    await store.receive(.view(.connectStream))
+
+    // Third language change
+    await store.send(.view(.changeLanguage("ko"))) {
+      $0.selectedLangCode = "ko"
+      $0.isShowingLanguageSheet = false
+      $0.chatList = [] // Chat list should be cleared again
+    }
+
+    await store.receive(.langSetLoaded(LangSet(data: ["en": "English", "ko": "한국어"]))) {
+      $0.langSet = LangSet(data: ["en": "English", "ko": "한국어"])
+      $0.hasLoadedLangSet = true
+    }
+
+    // Should connect stream again
+    await store.receive(.view(.connectStream))
+    
+    // Cleanup: disconnect the stream to end the test properly
+    await store.send(.view(.disconnectStream))
+    
+    await store.finish()
   }
 
   func testBindingAction() async {

--- a/iPlayground/NowWidget/Provider.swift
+++ b/iPlayground/NowWidget/Provider.swift
@@ -129,7 +129,8 @@ struct Provider: TimelineProvider {
     }
 
     // Filter entries to only include future ones
-    let finalEntries = entries
+    let finalEntries =
+      entries
       .sorted(using: KeyPathComparator(\.date))
       .filter { $0.date >= now }
     return finalEntries

--- a/iPlayground/iPlayground.xcodeproj/project.pbxproj
+++ b/iPlayground/iPlayground.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -392,6 +393,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 			};
 			name = Release;
 		};

--- a/iPlayground/iPlayground/Localizable.xcstrings
+++ b/iPlayground/iPlayground/Localizable.xcstrings
@@ -1,0 +1,23 @@
+{
+  "sourceLanguage" : "zh-Hant",
+  "strings" : {
+    "iPlayground" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iPlayground"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iPlayground"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.1"
+}


### PR DESCRIPTION
## Summary
- Update default Chinese mapping in LiveTranslationFeature to Traditional Chinese instead of Simplified Chinese
- Clear chat list when changing languages to avoid outdated translations 
- Add comprehensive tests for language change behavior including multiple language switches

## Test plan
- [x] Verify default Chinese mapping points to Traditional Chinese (zh-TW)
- [x] Confirm chat list clears on language change
- [x] Test multiple language changes work correctly 
- [x] Ensure fresh stream connection after language change
- [x] Run existing test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)