### PR TITLE
Update Japanese translation for event completion message

### DIFF
--- a/Sources/Views/Resources/Localizable.xcstrings
+++ b/Sources/Views/Resources/Localizable.xcstrings
@@ -262,22 +262,6 @@
         }
       }
     },
-    "今年的活動已結束，感謝您的參與！" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The conference is over. Thanks for joining us!"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今年のカンファレンスは終了しました。ご参加いただきありがとうございました！"
-          }
-        }
-      }
-    },
     "個人贊助" : {
       "localizations" : {
         "en" : {
@@ -478,6 +462,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "国立政治大学 CPBAE"
+          }
+        }
+      }
+    },
+    "活動已結束，感謝您的參與！" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The conference is over. Thanks for joining us!"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イベントは終了しました。ご参加ありがとうございました！"
           }
         }
       }

--- a/Sources/Views/Today/TodayView.swift
+++ b/Sources/Views/Today/TodayView.swift
@@ -104,7 +104,7 @@ struct TodayView: View {
           Text(
             """
             \(Text(verbatim: "iPlayground").foregroundStyle(Color(.iPlaygroundBlue))) \(Text(verbatim: "2025").foregroundStyle(Color(.iPlaygroundYellow)))
-            \(Text("今年的活動已結束，感謝您的參與！", bundle: .module).foregroundStyle(Color(.iPlaygroundPink)))
+            \(Text("活動已結束，感謝您的參與！", bundle: .module).foregroundStyle(Color(.iPlaygroundPink)))
             """
           )
           .font(.headline)

--- a/iPlayground/NowWidget/Localizable.xcstrings
+++ b/iPlayground/NowWidget/Localizable.xcstrings
@@ -1,16 +1,6 @@
 {
   "sourceLanguage" : "zh-Hant",
   "strings" : {
-    "%@\n%@" : {
-      "localizations" : {
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@\n%2$@"
-          }
-        }
-      }
-    },
     "%@ %@\n%@" : {
       "localizations" : {
         "zh-Hant" : {
@@ -19,7 +9,8 @@
             "value" : "%1$@ %2$@\n%3$@"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "%@ %@%@" : {
       "localizations" : {
@@ -44,12 +35,12 @@
       "shouldTranslate" : false
     },
     "2025" : {
-
+      "shouldTranslate" : false
     },
     "iPlayground" : {
       "shouldTranslate" : false
     },
-    "今年的活動已結束，感謝您的參與！" : {
+    "活動已結束，感謝您的參與！" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -60,7 +51,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "今年のカンファレンスは終了しました。ご参加いただきありがとうございました！"
+            "value" : "イベントは終了しました。ご参加ありがとうございました！"
           }
         }
       }

--- a/iPlayground/NowWidget/NowWidgetEntryView.swift
+++ b/iPlayground/NowWidget/NowWidgetEntryView.swift
@@ -87,8 +87,8 @@ struct NowWidgetEntryView: View {
   private var afterEventView: some View {
     Text(
       """
-      \(Text("iPlayground").foregroundStyle(Color(.iPlaygroundBlue)))
-      \(Text("今年的活動已結束，感謝您的參與！").foregroundStyle(Color(.iPlaygroundPink)))
+      \(Text(verbatim: "iPlayground").foregroundStyle(Color(.iPlaygroundBlue))) \(Text(verbatim: "2025").foregroundStyle(Color(.iPlaygroundYellow)))
+      \(Text("活動已結束，感謝您的參與！").foregroundStyle(Color(.iPlaygroundPink)))
       """
     )
     .font(.headline)


### PR DESCRIPTION
## Summary
• Updated Chinese text from "今年的活動已結束" to "活動已結束" (removed "今年的" - "this year")
• Added corresponding Japanese translation: "イベントは終了しました。ご参加ありがとうございました！"
• Updated both main app and widget localization files and Swift code

## Test plan
- [x] Run swift-format
- [x] All tests pass
- [x] Localization updates applied to both main app and widget

🤖 Generated with [Claude Code](https://claude.ai/code)